### PR TITLE
Allow entries in 'rolemap' in loginldap.yaml to use nested mappings for more control.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,13 @@ You can define additional roles to map to LDAP groups in `loginldap.yaml`.  For 
 ```
 rolemap:
   student: CN=Grad,ou=People,dc=example,dc=com
-  hqstaff: CN=hqstaff,ou=People,dc=example,dc=com
+  hqstaff:
+    login: CN=hqstaff,ou=People,dc=example,dc=com
+    super: CN=hqadmin,ou=People,dc=example,dc=com
 ```
 
-This would allow you to restrict access to `student.login` or `hqstaff.login` in your page headers in order to restrict access to the respective LDAP groups.
+This would allow you to restrict access to `student.login`, `hqstaff.login`, or `hqstaff.super` in your page headers in order to restrict access to the respective LDAP groups.
+*Note: In the example above, `student.login` is infered, but `hqstaff.login` must be explicitly defined to use it.*
 
 ## Create Private Areas
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ rolemap:
 
 This would allow you to restrict access to `student.login`, `hqstaff.login`, or `hqstaff.super` in your page headers in order to restrict access to the respective LDAP groups.
 
-**Note: In the example above, `student.login` is infered, but `hqstaff.login` must be explicitly defined to use it.**
+**Note: In the example above, `student.login` is implied, but `hqstaff.login` must be explicitly defined to grant only that level of access. Meeting the requirements for any group under `hqstaff.*` will also grant that user `hqstaff.login`.**
 
 ## Create Private Areas
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ rolemap:
 ```
 
 This would allow you to restrict access to `student.login`, `hqstaff.login`, or `hqstaff.super` in your page headers in order to restrict access to the respective LDAP groups.
-*Note: In the example above, `student.login` is infered, but `hqstaff.login` must be explicitly defined to use it.*
+
+**Note: In the example above, `student.login` is infered, but `hqstaff.login` must be explicitly defined to use it.**
 
 ## Create Private Areas
 

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -298,10 +298,9 @@ class Controller
                     foreach($value as $roleChild => $ldapgroup) {
                         if (in_array($ldapgroup, $ldapuser[$config['attr']['groups']])) {
                             if (!isset($accessGroup)) {
-                                $accessGroup = array($roleChild => 'true');
-                            } else {
-                                $accessGroup[$roleChild] = 'true';
+                                $accessGroup = array('login' => 'true');
                             }
+                            $accessGroup[$roleChild] = 'true';
                         }
                     }
 

--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -288,9 +288,25 @@ class Controller
         // Assign any additional roles
         $rolemap = $this->grav['config']->get('plugins.loginldap.rolemap');
         if ((is_array($rolemap)) && (isset($ldapuser[$config['attr']['groups']]))) {
-            foreach ($rolemap as $role => $ldapgroup) {
-                if (in_array($ldapgroup, $ldapuser[$config['attr']['groups']])) {
-                    $dataUser['access'][$role] = array('login' => 'true');
+            foreach ($rolemap as $role => $value) {
+                if (is_string($value)) {
+                    if (in_array($value, $ldapuser[$config['attr']['groups']])) {
+                        $dataUser['access'][$role] = array('login' => 'true');
+                    }
+                } elseif (is_array($value)) {
+                    $accessGroup = null;
+                    foreach($value as $roleChild => $ldapgroup) {
+                        if (in_array($ldapgroup, $ldapuser[$config['attr']['groups']])) {
+                            if (!isset($accessGroup)) {
+                                $accessGroup = array($roleChild => 'true');
+                            } else {
+                                $accessGroup[$roleChild] = 'true';
+                            }
+                        }
+                    }
+
+                    if (isset($accessGroup))
+                        $dataUser['access'][$role] = $accessGroup;
                 }
             }
         }


### PR DESCRIPTION
Allow entries in 'rolemap' in loginldap.yaml to use nested mappings for more control.
Now you may define the following ...

```
rolemap:
  student: CN=Grad,ou=People,dc=example,dc=com
  hqstaff:
    login: CN=hqstaff,ou=People,dc=example,dc=com
    super: CN=hqadmin,ou=People,dc=example,dc=com
```