### PR TITLE
Store groups user belongs to in user's data.

### DIFF
--- a/classes/Controller.php
+++ b/classes/Controller.php
@@ -291,6 +291,7 @@ class Controller
             foreach ($rolemap as $role => $ldapgroup) {
                 if (in_array($ldapgroup, $ldapuser[$config['attr']['groups']])) {
                     $dataUser['access'][$role] = array('login' => 'true');
+                    $dataUser['groups'][] = $role;
                 }
             }
         }


### PR DESCRIPTION
Creating array of groups allows further fine tuning user's rights via groups.yaml file. One can define group 'systemadmin' using rolemap in loginldap.yaml:

```
rolemap:
  systemadmin: CN=SystemAdministrator,OU=Roles,DC=com
```

and than for example give some rights to the users belonging to this group in groups.yaml:

```
systemadmin:
  access:
    site:
      front-end: true
```